### PR TITLE
Fix logging in.

### DIFF
--- a/logout.html
+++ b/logout.html
@@ -28,9 +28,9 @@
             }),
             contentType: 'application/json',
             dataType: 'json',
-            /*xhrFields: {
+            xhrFields: {
                withCredentials: true
-            }, */
+            },
             crossDomain: true
           })
           .then(res => {


### PR DESCRIPTION
If you don't specify `xhrFields: {withCredentials:true}`, then the `Set-Cookie` response header will not be respected. Which means no cookie will be set.
